### PR TITLE
Disable PyAutoGUI failsafe

### DIFF
--- a/AutoGuard.py
+++ b/AutoGuard.py
@@ -1,6 +1,13 @@
 import tkinter as tk
 from tkinter import ttk
 import pyautogui
+
+# Disable PyAutoGUI's failsafe so cursor moves near the edges do not
+# raise an exception. This mirrors the suggestion given when running
+# the program where a `pyautogui.FailSafeException` was raised.
+# NOTE: Disabling the failsafe is generally discouraged but is useful
+# in controlled environments like this simulator.
+pyautogui.FAILSAFE = False
 from datetime import datetime
 
 class AutoGuard:


### PR DESCRIPTION
## Summary
- disable PyAutoGUI's failsafe to prevent the simulation from stopping when the mouse reaches a screen corner

## Testing
- `python3 -m py_compile AutoGuard.py`


------
https://chatgpt.com/codex/tasks/task_e_686269ff885c8325a1a22a1e2b5c5fea